### PR TITLE
Method to unmask and remove the keyup event of the element.

### DIFF
--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -37,6 +37,18 @@
     this.elements = elements;
   };
 
+  VanillaMasker.prototype.unbindElementToMask = function() {
+    for (var i = 0, len = this.elements.length; i < len; i++) {
+      this.elements[i].lastOutput = "";
+      this.elements[i].onkeyup = false;
+      this.elements[i].onkeydown = false;
+      
+      if (this.elements[i].value.length) {
+        this.elements[i].value = this.elements[i].value.replace(/\D/g, '');
+      }
+    }
+  };
+
   VanillaMasker.prototype.bindElementToMask = function(maskFunction) {
     var that = this,
         onType = function(e) {
@@ -55,13 +67,7 @@
     ;
     for (var i = 0, len = this.elements.length; i < len; i++) {
       this.elements[i].lastOutput = "";
-      if (this.elements[i].addEventListener) {
-        this.elements[i].addEventListener("keyup", onType);
-        this.elements[i].addEventListener("keydown", onType);
-      } else {
-        this.elements[i].attachEvent("onkeyup", onType);
-        this.elements[i].attachEvent("onkeydown", onType);
-      }
+      this.elements[i].onkeyup = onType;
       if (this.elements[i].value.length) {
         this.elements[i].value = VMasker[maskFunction](this.elements[i].value, this.opts);
       }
@@ -81,6 +87,10 @@
   VanillaMasker.prototype.maskPattern = function(pattern) {
     this.opts = {pattern: pattern};
     this.bindElementToMask("toPattern");
+  };
+
+  VanillaMasker.prototype.unMask = function() {
+    this.unbindElementToMask();
   };
 
   var VMasker = function(el) {


### PR DESCRIPTION
I needed a method to reset the mask and events in a field. Now is possible to use the "unmask ()" method and then apply any mask's pattern again.
### Example of usage:

``` javascript
var el = document.querySelector(".mask.phone");
VMasker(el).unMask();
```

In my specific case, the problem was with the numbers of Brazilian cell phones, which have a ninth digit in some cities as São Paulo. I needed to apply mask patterns according to the number of typed characters. Below my solution using the new method.

HTML markup 

``` html
<input type="text" name="phone" id="phone" class="mask phone">
```

Javascript code

``` javascript
  //applies default mask pattern
  VMasker(document.querySelector(".mask.phone")).maskPattern("(99) 9999-9999");            

  //sets keyup's event to check which mask pattern will be used
  var phones = Array.prototype.slice.call(document.querySelectorAll('.mask.phone'));
  phones.forEach(function(el, i) {
      addEvent(el, 'keyup', function(){
          var phone = el.value,
          digits = phone.replace(/\D/g, '');

         // removes the last mask pattern and keyup event setted by maskPattern method
          VMasker(el).unMask();

         // verify length of digits and apply correct mask pattern
          if(digits.length > 10){
              VMasker(el).maskPattern("(99) 99999-9999");
          }else{
              VMasker(el).maskPattern("(99) 9999-9999");
          }
      });
  });
```
### Note:

I changed the way it was applied the keyup event to "DOM Level 0 property" only to override of the event "keyup" outside the function's scope "bindElementToMask" with an easier way. :D
