### PR TITLE
Bugfix #20 - MaskPattern any characters

### DIFF
--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -42,7 +42,7 @@
       this.elements[i].lastOutput = "";
       this.elements[i].onkeyup = false;
       this.elements[i].onkeydown = false;
-      
+
       if (this.elements[i].value.length) {
         this.elements[i].value = this.elements[i].value.replace(/\D/g, '');
       }
@@ -146,17 +146,17 @@
 
   VMasker.toPattern = function(value, opts) {
     var pattern = (typeof opts === 'object' ? opts.pattern : opts),
-        patternDigits = pattern.replace(/\D/g, ''),
+        patternChars = pattern.replace(/[^0-9a-zA-Z]/g, ''),
         output = pattern.split(""),
         values = value.toString().replace(/[^0-9a-zA-Z]/g, ""),
-        digitsValues = values.replace(/\D/g, ''),
+        charsValues = values.replace(/[^0-9a-zA-Z]/g, ''),
         index = 0,
         i
     ;
     for (i = 0; i < output.length; i++) {
-      
+
       if (index >= values.length) {
-        if (patternDigits.length == digitsValues.length) {
+        if (patternChars.length == charsValues.length) {
           return output.join("");
         }
         break;

--- a/tests/pattern_spec.js
+++ b/tests/pattern_spec.js
@@ -79,4 +79,8 @@ describe("VanillaMasker.toPattern", function() {
   it('returns "9B.GR.D08X0.4.G.117974" pattern when input is 9BGRD08X04G117974', function() {
     expect(VMasker.toPattern('9BGRD08X04G117974', 'SS.SS.SSSSS.S.S.SSSSSS')).toEqual('9B.GR.D08X0.4.G.117974');
   });
+
+  it('returns "BB.G" pattern when input is 9BG', function() {
+    expect(VMasker.toPattern('BBG', 'SS.SS.SSSSS.S.S.SSSSSS')).toEqual('BB.G');
+  });
 });


### PR DESCRIPTION
When I have a pattern with 'S' and apply the mask to a "incompleted" string , the remaining characters are filled with S.

eg. 

1) typing "A" on pattern "SS-S" turns into "AS-S";

2) In http://bankfacil.github.io/vanilla-masker/demo.html on input "Vehicle identification" when I type any characters, the remaining characters are filled with 'S'. But when I type any number, the component works.
