### PR TITLE
[W.I.P] - Add support for negative values. Closes #33

### DIFF
--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -22,13 +22,15 @@
       mergeMoneyOptions = function(opts) {
         opts = opts || {};
         opts = {
+          delimiter: opts.delimiter || ".",
+          lastOutput: opts.lastOutput,
           precision: opts.hasOwnProperty("precision") ? opts.precision : 2,
           separator: opts.separator || ",",
-          delimiter: opts.delimiter || ".",
-          unit: opts.unit && (opts.unit.replace(/[\s]/g,'') + " ") || "",
+          showPositiveSignal: opts.showPositiveSignal,
+          showSignal: opts.showSignal,
           suffixUnit: opts.suffixUnit && (" " + opts.suffixUnit.replace(/[\s]/g,'')) || "",
-          zeroCents: opts.zeroCents,
-          lastOutput: opts.lastOutput
+          unit: opts.unit && (opts.unit.replace(/[\s]/g,'') + " ") || "",
+          zeroCents: opts.zeroCents
         };
         opts.moneyPrecision = opts.zeroCents ? 0 : opts.precision;
         return opts;
@@ -149,6 +151,10 @@
     }
     masked = masked.replace(clearDelimiter, "");
     masked = masked.length ? masked : "0";
+    signal = "";
+    if(opts.showSignal === true) {
+      signal = value < 0 ? "-" : (opts.showPositiveSignal === true ? "+" : "");
+    }
     if (!opts.zeroCents) {
       var beginCents = number.length - opts.precision,
           centsValue = number.substr(beginCents, opts.precision),
@@ -157,7 +163,7 @@
       ;
       cents = (cents + centsValue).slice(-centsSliced);
     }
-    var output = opts.unit + masked + opts.separator + cents + opts.suffixUnit;
+    var output = opts.unit + signal + masked + opts.separator + cents + opts.suffixUnit;
     return output.replace(clearSeparator, "");
   };
 

--- a/tests/money_spec.js
+++ b/tests/money_spec.js
@@ -80,4 +80,16 @@ describe("VanillaMasker.toMoney", function() {
     expect(VMasker.toMoney(100000000, {zeroCents: true})).toEqual('100.000.000,00');
   });
 
+  it('returns -3,75 when showSignal is true', function() {
+    expect(VMasker.toMoney(-375, {showSignal: true})).toEqual('-3,75');
+  });
+
+  it('returns 3,75 when showSignal is true and showPositiveSignal is false(default)', function() {
+    expect(VMasker.toMoney(375, {showSignal: true})).toEqual('3,75');
+  });
+
+  it('returns +3,75 when showSignal is true and showPositiveSignal is true', function() {
+    expect(VMasker.toMoney(375, {showSignal: true, showPositiveSignal: true})).toEqual('+3,75');
+  });
+
 });


### PR DESCRIPTION
I don't know if this PR is valid, but worked for me =). In order to add support for negative money values (as mentioned on #33), this PR adds support for negative and positive signal as an optional parameter.

![image](https://cloud.githubusercontent.com/assets/771411/9190032/0b407452-3fc7-11e5-9206-2f436f8cde21.png)
