### PR TITLE
chore(links): update links references

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,4 +234,4 @@ Thiago Lagden - lagden@gmail.com
 
 # License
 
-MIT License: http://bankfacil.mit-license.org
+MIT License: http://vanilla-masker.mit-license.org

--- a/bankfacil:vanilla-masker/package.js
+++ b/bankfacil:vanilla-masker/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: "VanillaMasker is a pure javascript input mask.",
   version: "1.0.9",
-  git: "https://github.com/Creditas/vanilla-masker"
+  git: "https://github.com/vanilla-masker/vanilla-masker"
 });
 
 Package.onUse(function(api) {

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "vanilla-masker",
   "version": "1.1.1",
   "description": "VanillaMasker is a pure javascript input mask.",
-  "homepage": "https://fleury.io/vanilla-masker/",
+  "homepage": "https://vanilla-masker.github.io/vanilla-masker/",
   "repository": {
     "type": "git",
     "url": "git://github.com/Creditas/vanilla-masker.git"
@@ -15,8 +15,8 @@
     "Leonardo Andrade <leonardopandrade@gmail.com>"
   ],
   "main": "lib/vanilla-masker.js",
-  "license": "MIT <http://bankfacil.mit-license.org>",
-  "bugs": "https://github.com/fernandofleury/vanilla-masker/issues",
+  "license": "MIT <http://vanilla-masker.mit-license.org>",
+  "bugs": "https://github.com/vanilla-masker/vanilla-masker/issues",
   "ignore": [
     "*.yml",
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/fernandofleury/vanilla-masker.git"
+    "url": "git://github.com/vanilla-masker/vanilla-masker.git"
   },
   "keywords": [
     "mask input",
@@ -25,9 +25,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/fernandofleury/vanilla-masker/issues"
+    "url": "https://github.com/vanilla-masker/vanilla-masker/issues"
   },
-  "homepage": "https://fleury.io/vanilla-masker/",
+  "homepage": "https://vanilla-masker.github.io/vanilla-masker/",
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",


### PR DESCRIPTION
Update links from `fleury.io`, `Creditas` and `bankfacil` to `vanilla-masker`.

close #123 #107