### PR TITLE
chore(home): change links to organization reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <meta charset="UTF-8">
-    <title>VanillaMasker by Creditas</title>
+    <title>VanillaMasker</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -13,24 +13,22 @@
     <section class="page-header">
       <h1 class="project-name">VanillaMasker</h1>
       <h2 class="project-tagline">A pure javascript input masker</h2>
-      <a href="https://github.com/Creditas/vanilla-masker" class="btn">View on GitHub</a>
-      <a href="https://github.com/Creditas/vanilla-masker/zipball/master" class="btn">Download .zip</a>
-      <a href="https://github.com/Creditas/vanilla-masker/tarball/master" class="btn">Download .tar.gz</a>
+      <a href="https://github.com/vanilla-masker/vanilla-masker" class="btn">View on GitHub</a>
+      <a href="https://github.com/vanilla-masker/vanilla-masker/zipball/master" class="btn">Download .zip</a>
+      <a href="https://github.com/vanilla-masker/vanilla-masker/tarball/master" class="btn">Download .tar.gz</a>
     </section>
 
     <section class="main-content">
       <h1>
 <a id="whats-this" class="anchor" href="#whats-this" aria-hidden="true"><span class="octicon octicon-link"></span></a>What's this</h1>
 
-<p><a href="https://travis-ci.org/Creditas/vanilla-masker"><img src="https://travis-ci.org/Creditas/vanilla-masker.svg" alt="Build Status"></a>
-<a href="https://codeclimate.com/github/BankFacil/vanilla-masker"><img src="https://codeclimate.com/github/BankFacil/vanilla-masker.png" alt="Code Climate"></a>
-<a href="https://saucelabs.com/u/bankfacil_dev"><img src="https://saucelabs.com/browser-matrix/bankfacil_dev.svg" alt="Sauce Test Status"></a></p>
+<p><a href="https://travis-ci.org/vanilla-masker/vanilla-masker"><img src="https://travis-ci.org/vanilla-masker/vanilla-masker.svg" alt="Build Status"></a>
 
 <p>It's a pure JavaScript mask input.<br>
 Now you can use a simple and pure javascript lib to mask your input elements, without need to load jQuery or Zepto to do it.</p>
 
 <p>Let's live a lightweight client-side world using micro libraries as VanillaMasker is!<br>
-Don't worry about where this will work, because this is a cross-browser and cross-device library. And if you find any bug, please let us know about it <a href="https://github.com/Creditas/vanilla-masker/issues">reporting an issue</a>.</p>
+Don't worry about where this will work, because this is a cross-browser and cross-device library. And if you find any bug, please let us know about it <a href="https://github.com/vanilla-masker/vanilla-masker/issues">reporting an issue</a>.</p>
 
 <p>If you wanna see how this lib works, click to test this <a href="https://vanilla-masker.github.io/vanilla-masker/demo.html">demo page</a>.</p>
 
@@ -42,17 +40,17 @@ Don't worry about where this will work, because this is a cross-browser and cros
 
 <ul>
 <li>
-<a href="https://raw.githubusercontent.com/Creditas/vanilla-masker/1.1.0/lib/vanilla-masker.js">development version</a> (6.2 Kbytes);</li>
+<a href="https://raw.githubusercontent.com/vanilla-masker/vanilla-masker/1.1.1/lib/vanilla-masker.js">development version</a> (6.2 Kbytes);</li>
 <li>
-<a href="https://raw.githubusercontent.com/Creditas/vanilla-masker/1.1.0/build/vanilla-masker.min.js">minified version</a> (3.24 Kbytes);</li>
+<a href="https://raw.githubusercontent.com/vanilla-masker/vanilla-masker/1.1.1/build/vanilla-masker.min.js">minified version</a> (3.24 Kbytes);</li>
 <li>
-<a href="https://raw.githubusercontent.com/Creditas/vanilla-masker/1.1.0/build/vanilla-masker.min.gz.js">gzipped version</a> (1.3 Kbytes);</li>
+<a href="https://raw.githubusercontent.com/vanilla-masker/vanilla-masker/1.1.1/build/vanilla-masker.min.gz.js">gzipped version</a> (1.3 Kbytes);</li>
 </ul>
 
 <p>We have the following CDN available, for development or minified versions:</p>
 
-<p><code>//cdn.jsdelivr.net/vanilla-masker/1.1.0/vanilla-masker.js</code><br>
-<code>//cdn.jsdelivr.net/vanilla-masker/1.1.0/vanilla-masker.min.js</code></p>
+<p><code>//cdn.jsdelivr.net/npm/vanilla-masker@1.1.1/lib/vanilla-masker.js</code><br>
+<code>//cdn.jsdelivr.net/npm/vanilla-masker@1.1.1/build/vanilla-masker.min.js</code></p>
 
 <p>We intent to automatically send new versions to the CDN, but keep in mind that the version you want might not be available there. Of course you can always download and put it in your own site. </p>
 
@@ -192,7 +190,7 @@ VMasker.<span class="pl-c1">toPattern</span>(<span class="pl-s"><span class="pl-
 <ul>
 <li>Install node.js - <a href="http://nodejs.org/download">http://nodejs.org/download</a>
 </li>
-<li>Clone this repository - <code>git clone git@github.com:Creditas/vanilla-masker.git</code>
+<li>Clone this repository - <code>git clone git@github.com:vanilla-masker/vanilla-masker.git</code>
 </li>
 <li>Install Grunt - <code>npm install -g grunt-cli</code>
 </li>
@@ -269,13 +267,13 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="110---13082015" class="anchor" href="#110---13082015" aria-hidden="true"><span class="octicon octicon-link"></span></a>1.1.0 - 13/08/2015</h2>
 
 <ul>
-<li>Improved demo page layout - <a href="https://github.com/Creditas/vanilla-masker/pull/40">See this pull request</a>
+<li>Improved demo page layout - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/40">See this pull request</a>
 </li>
-<li>Fixed bower.json - <a href="https://github.com/Creditas/vanilla-masker/pull/43">See this pull request</a>
+<li>Fixed bower.json - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/43">See this pull request</a>
 </li>
-<li>When backspace is pressed the pattern is kept - <a href="https://github.com/Creditas/vanilla-masker/pull/47">See this pull request</a>
+<li>When backspace is pressed the pattern is kept - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/47">See this pull request</a>
 </li>
-<li>Enabled sauce-labs on Travis - <a href="https://github.com/Creditas/vanilla-masker/pull/44">See this pull request</a>
+<li>Enabled sauce-labs on Travis - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/44">See this pull request</a>
 </li>
 </ul>
 
@@ -283,7 +281,7 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="109---07042015" class="anchor" href="#109---07042015" aria-hidden="true"><span class="octicon octicon-link"></span></a>1.0.9 - 07/04/2015</h2>
 
 <ul>
-<li>Added optional placeholder feature for patterns - <a href="https://github.com/Creditas/vanilla-masker/pull/35">See this pull request</a>
+<li>Added optional placeholder feature for patterns - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/35">See this pull request</a>
 </li>
 </ul>
 
@@ -291,7 +289,7 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="108---27012015" class="anchor" href="#108---27012015" aria-hidden="true"><span class="octicon octicon-link"></span></a>1.0.8 - 27/01/2015</h2>
 
 <ul>
-<li>Bug fix #29 - <a href="https://github.com/Creditas/vanilla-masker/pull/29">See this pull request</a>
+<li>Bug fix #29 - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/29">See this pull request</a>
 </li>
 </ul>
 
@@ -299,7 +297,7 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="107---26012015" class="anchor" href="#107---26012015" aria-hidden="true"><span class="octicon octicon-link"></span></a>1.0.7 - 26/01/2015</h2>
 
 <ul>
-<li>Bug fix #28 - <a href="https://github.com/Creditas/vanilla-masker/issues/28">See this issue</a>
+<li>Bug fix #28 - <a href="https://github.com/vanilla-masker/vanilla-masker/issues/28">See this issue</a>
 </li>
 </ul>
 
@@ -307,9 +305,9 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="106---19122014" class="anchor" href="#106---19122014" aria-hidden="true"><span class="octicon octicon-link"></span></a>1.0.6 - 19/12/2014</h2>
 
 <ul>
-<li>Bug fix #26 - <a href="https://github.com/Creditas/vanilla-masker/pull/26">See this pull request</a>
+<li>Bug fix #26 - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/26">See this pull request</a>
 </li>
-<li>Bug fix #24 - <a href="https://github.com/Creditas/vanilla-masker/pull/24">See this pull request</a>
+<li>Bug fix #24 - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/24">See this pull request</a>
 </li>
 </ul>
 
@@ -317,7 +315,7 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="105---06122014" class="anchor" href="#105---06122014" aria-hidden="true"><span class="octicon octicon-link"></span></a>1.0.5 - 06/12/2014</h2>
 
 <ul>
-<li>Bug fix - <a href="https://github.com/Creditas/vanilla-masker/pull/19">See this pull request</a>
+<li>Bug fix - <a href="https://github.com/vanilla-masker/vanilla-masker/pull/19">See this pull request</a>
 </li>
 </ul>
 
@@ -410,45 +408,28 @@ Leonardo Andrade - <a href="mailto:leonardopandrade@gmail.com">leonardopandrade@
 <a id="010" class="anchor" href="#010" aria-hidden="true"><span class="octicon octicon-link"></span></a>0.1.0</h2>
 
 <ul>
-<li>Added maskMoney</li>
-<li>Added Bower support</li>
-<li>Added Demo page</li>
-<li>Added JSHint</li>
-<li>Mobile browser support</li>
-<li>Added Grunt build</li>
-<li>Added Travis-CI</li>
-<li>Added CodeClimate</li>
+  <li>Added maskMoney</li>
+  <li>Added Bower support</li>
+  <li>Added Demo page</li>
+  <li>Added JSHint</li>
+  <li>Mobile browser support</li>
+  <li>Added Grunt build</li>
+  <li>Added Travis-CI</li>
+  <li>Added CodeClimate</li>
 </ul>
 
 <h1>
 <a id="license" class="anchor" href="#license" aria-hidden="true"><span class="octicon octicon-link"></span></a>License</h1>
 
-<p>MIT License: <a href="http://bankfacil.mit-license.org">http://bankfacil.mit-license.org</a></p>
+<p>MIT License: <a href="http://vanilla-masker.mit-license.org">http://vanilla-masker.mit-license.org</a></p>
 
-<h1>
-<a id="powered-by" class="anchor" href="#powered-by" aria-hidden="true"><span class="octicon octicon-link"></span></a>Powered by</h1>
 
-<p>Bankfacil: <a href="http://www.bankfacil.com.br">http://www.bankfacil.com.br</a><br>
-Join our team! Read about our <a href="https://www.bankfacil.com.br/dev">development culture</a> and check our <a href="https://bankfacil.recruiterbox.com/">open positions</a></p>
+  <footer class="site-footer">
+    <span class="site-footer-owner"><a href="https://github.com/vanilla-masker/vanilla-masker">VanillaMasker</a> is maintained by <a href="https://github.com/vanilla-masker">vanilla-masker organization</a>.</span>
 
-      <footer class="site-footer">
-        <span class="site-footer-owner"><a href="https://github.com/Creditas/vanilla-masker">VanillaMasker</a> is maintained by <a href="https://github.com/Creditas">Creditas</a>.</span>
-
-        <span class="site-footer-credits">This page was generated by <a href="https://pages.github.com">GitHub Pages</a> using the <a href="https://github.com/jasonlong/cayman-theme">Cayman theme</a> by <a href="https://twitter.com/jasonlong">Jason Long</a>.</span>
-      </footer>
-
-    </section>
-
-            <script type="text/javascript">
-            var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-            document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-          </script>
-          <script type="text/javascript">
-            try {
-              var pageTracker = _gat._getTracker("UA-31003046-6");
-            pageTracker._trackPageview();
-            } catch(err) {}
-          </script>
+    <span class="site-footer-credits">This page was generated by <a href="https://pages.github.com">GitHub Pages</a> using the <a href="https://github.com/jasonlong/cayman-theme">Cayman theme</a> by <a href="https://twitter.com/jasonlong">Jason Long</a>.</span>
+  </footer>
+</section>
 
   </body>
 </html>


### PR DESCRIPTION
- Fixed old links
- New cdn links to the [last realease](https://github.com/vanilla-masker/vanilla-masker/releases)
- Remove g.a tracking