### PR TITLE
Fix ignoring of wordlike characters that are not special characters

### DIFF
--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -97,7 +97,7 @@
     this.opts = {};
     this.bindElementToMask("toNumber");
   };
-  
+
   VanillaMasker.prototype.maskAlphaNum = function() {
     this.opts = {};
     this.bindElementToMask("toAlphaNumeric");
@@ -177,7 +177,7 @@
         outputLength = output.length,
         placeholder = (typeof opts === 'object' ? opts.placeholder : undefined)
     ;
-    
+
     for (i = 0; i < outputLength; i++) {
       // Reached the end of input
       if (index >= values.length) {
@@ -204,7 +204,11 @@
           else{
             return output.slice(0, i).join("");
           }
+        // exact match for a non-magic character
+        } else if (output[i] === values[index]) {
+          index++;
         }
+
       }
     }
     return output.join("").substr(0, i);
@@ -213,7 +217,7 @@
   VMasker.toNumber = function(value) {
     return value.toString().replace(/(?!^-)[^0-9]/g, "");
   };
-  
+
   VMasker.toAlphaNumeric = function(value) {
     return value.toString().replace(/[^a-z0-9 ]+/i, "");
   };

--- a/public/index.html
+++ b/public/index.html
@@ -56,6 +56,9 @@
 			<label for="phoneValues">Phone with values</label>
 			<input type="text" id="phoneValues" value="3141232312">
 
+			<label for="phoneValues">Phone with leading +1</label>
+			<input type="text" id="leadingPlus" value="8888888888">
+
 			<label for="date">Date</label>
 			<input type="text" id="date">
 
@@ -87,6 +90,7 @@
 				// #maskPattern
 				VMasker(document.getElementById("phone")).maskPattern('(99) 9999-9999');
 				VMasker(document.getElementById("phoneValues")).maskPattern('(99) 9999-9999');
+				VMasker(document.getElementById("leadingPlus")).maskPattern('+1 (999) 999-9999');
 				VMasker(document.getElementById("date")).maskPattern('99/99/9999');
 				VMasker(document.getElementById("doc")).maskPattern('999.999.999-99');
 				VMasker(document.getElementById("carPlate")).maskPattern('AAA-9999');

--- a/tests/pattern_spec.js
+++ b/tests/pattern_spec.js
@@ -48,6 +48,17 @@ describe("VanillaMasker.toPattern", function() {
     expect(VMasker.toPattern('1011444444', '+99 99 9999-99')).toEqual('+10 11 4444-44');
   });
 
+  it('returns "+1 (888) 888-8888" pattern when input is 8888888888', function() {
+    expect(VMasker.toPattern('8888888888', '+1 (999) 999-9999')).toEqual('+1 (888) 888-8888');
+  });
+
+  it('returns "+1 (888) 888-8" pattern when input is 8888888', function() {
+    expect(VMasker.toPattern('8888888', '+1 (999) 999-9999')).toEqual('+1 (888) 888-8');
+  });
+  it('returns "+1 (888) 888-8" pattern when input is +1 (888) 888-8', function() {
+    expect(VMasker.toPattern('+1 (888) 888-8', '+1 (999) 999-9999')).toEqual('+1 (888) 888-8');
+  });
+
   it('returns "12/12/2000" pattern when input is 12122000', function() {
     expect(VMasker.toPattern(12122000, '99/99/9999')).toEqual('12/12/2000');
   });


### PR DESCRIPTION
This fixes issue #92 by allowing the masker to correctly ignore characters that are "wordlike" (number or letter) but not one of the special masking characters(9, A, S).

Without this fix, while non-word characters like '+', '(', and ' ' are properly ignored by the masker, wordlike characters like '1', '0', or 't' result in buggy behavior and an unusable mask.

With this fix, those characters are ignored properly.

I've added tests around this behavior and verified all previous tests pass. I also added an example in public/index.html. Let me know if there's anything else you need.