### PR TITLE
Fix parsing of money strings already containing separators

### DIFF
--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -128,14 +128,25 @@
           zeroRegExp = new RegExp(zeroMatcher, "g"),
           digitsLength = value.toString().replace(/[\D]/g, "").length || 0,
           lastDigitLength = opts.lastOutput.toString().replace(/[\D]/g, "").length || 0
-      ;
+          ;
       value = value.toString().replace(zeroRegExp, "");
       if (digitsLength < lastDigitLength) {
         value = value.slice(0, value.length - 1);
       }
     }
-    var number = value.toString().replace(/[\D]/g, ""),
-        clearDelimiter = new RegExp("^(0|\\"+ opts.delimiter +")"),
+
+    var number = value.toString();
+    // if separator is in string, make sure we zero-pad to respect it
+    var separatorIndex = number.indexOf(opts.separator),
+        missingZeros = (opts.precision - (number.length - separatorIndex - 1));
+
+    if (separatorIndex !== -1 && (missingZeros > 0) ) {
+      number = number + ('0' * missingZeros);
+    }
+
+    number = number.replace(/[\D]/g, "");
+
+    var clearDelimiter = new RegExp("^(0|\\"+ opts.delimiter +")"),
         clearSeparator = new RegExp("(\\"+ opts.separator +")$"),
         money = number.substr(0, number.length - opts.moneyPrecision),
         masked = money.substr(0, money.length % 3),

--- a/tests/money_spec.js
+++ b/tests/money_spec.js
@@ -108,4 +108,8 @@ describe("VanillaMasker.toMoney", function() {
     expect(VMasker.toMoney('123', {precision: 5})).toEqual('0,00123');
   });
 
+  it('parses proper precision location from strings', function() {
+    expect(VMasker.toMoney('1,2', {precision: 2})).toEqual('1,20');
+  });
+
 });


### PR DESCRIPTION
Respects separators in the strings to be masked. Should fix https://github.com/vanilla-masker/vanilla-masker/issues/95 and https://github.com/vanilla-masker/vanilla-masker/issues/42